### PR TITLE
Prevent invalid table names from being computed.

### DIFF
--- a/lib/ocean-dynamo/schema.rb
+++ b/lib/ocean-dynamo/schema.rb
@@ -23,7 +23,7 @@ module OceanDynamo
 
 
     def compute_table_name
-      name.pluralize.underscore
+      name.pluralize.underscore.gsub('/', '_')
     end
 
 

--- a/spec/dummy/app/models/cloud_namespace/cloud_model.rb
+++ b/spec/dummy/app/models/cloud_namespace/cloud_model.rb
@@ -1,0 +1,30 @@
+class CloudNamespace::CloudModel < OceanDynamo::Table
+
+dynamo_schema(:uuid, create: true, table_name_suffix: Api.basename_suffix) do
+    attribute :credentials,          :string,      default: "blah"
+    attribute :token,                :string
+    attribute :steps,                :serialized,  default: []
+    attribute :max_seconds_in_queue, :integer,     default: 1.day
+    attribute :default_poison_limit, :integer,     default: 5
+    attribute :default_step_time,    :integer,     default: 30
+    attribute :created_by,           :string
+    attribute :updated_by,           :string
+    attribute :destroy_at,           :datetime
+    attribute :started_at,           :datetime
+    attribute :last_completed_step,  :integer
+    attribute :succeeded,            :boolean,     default: true
+    attribute :failed,               :boolean,     default: false
+    attribute :poison,               :boolean,     default: false
+    attribute :finished_at,          :datetime
+    attribute :gratuitous_float,     :float,       default: lambda { rand }
+    attribute :zalagadoola,          :string,      default: "Menchikaboola"
+    attribute :list,                 :string,      default: ["1", "2", "3"]
+    attribute :int,                  :integer,     default: 1066
+  end
+
+
+  validates_each :steps do |record, attr, value|
+    record.errors.add(attr, 'must be an Array') unless value.is_a?(Array)
+  end 
+
+end

--- a/spec/dynamo/aws_table_spec.rb
+++ b/spec/dynamo/aws_table_spec.rb
@@ -30,6 +30,10 @@ describe CloudModel do
     expect(CloudModel.table_name).to eq "cloud_models"
   end
 
+  it "should have a proper table_name derived from a namespaced class" do
+    expect(CloudNamespace::CloudModel.table_name).to eq "cloud_namespace_cloud_models"
+  end
+
   it "should have a table_name_prefix" do
     expect(CloudModel.table_name_prefix).to eq nil
     CloudModel.table_name_prefix = "foo_"


### PR DESCRIPTION
When a model is in namespace, Rails will compute the underscored name with a `/`. For example, `Foo::Bar` will become `foo/bar`. This results in the computed table name producing an invalid name on DynamoDB and will yield the following exception:

```
AWS::DynamoDB::Errors::ValidationException: 1 validation error detected: Value 'registry_user/audit_log_entries' at 'tableName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_.-]+
```

This fix replaces this character with an underscore.